### PR TITLE
Further improvement to memory usage

### DIFF
--- a/MEArec/generation_tools.py
+++ b/MEArec/generation_tools.py
@@ -94,8 +94,8 @@ def gen_recordings(params=None, templates=None, tempgen=None, spgen=None, verbos
     
     params_dict['spiketrains'] = spgen.info
     # Generate recordings
-    recgen = RecordingGenerator(spgen, tempgen, params_dict, tmp_h5=tmp_h5, verbose=verbose)
-    recgen.generate_recordings()
+    recgen = RecordingGenerator(spgen, tempgen, params_dict, verbose=verbose)
+    recgen.generate_recordings(tmp_h5=tmp_h5)
 
     print('Elapsed time: ', time.time() - t_start)
 

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -99,7 +99,7 @@ class RecordingGenerator:
         if self._is_h5 and self._h5file is not None:
             self._h5file.close()
 
-    def generate_recordings(self, tmp_h5=True):
+    def generate_recordings(self, tmp_h5=True, verbose=None):
         """
         Generates recordings
         Parameters
@@ -111,6 +111,9 @@ class RecordingGenerator:
             self._is_h5 = True
         else:
             self._is_h5 = False
+
+        if verbose is not None and isinstance(verbose, bool):
+            self._verbose = verbose
 
         params = deepcopy(self.params)
         temp_params = self.params['templates']
@@ -542,7 +545,6 @@ class RecordingGenerator:
                 if not drifting:
                     velocity_vector = None
                 else:
-                    drift_directions = np.array([(p[-1] - p[0]) / np.linalg.norm(p[-1] - p[0]) for p in template_locs])
                     drift_velocity_ums = drift_velocity / 60.
                     velocity_vector = drift_velocity_ums * preferred_dir
                     if self._verbose:
@@ -579,7 +581,7 @@ class RecordingGenerator:
                     st.annotate(bintype=templates_bin[i], mtype=template_celltypes[i], soma_position=template_locs[i])
 
             if overlap:
-                annotate_overlapping_spikes(spiketrains, overlapping_pairs=overlapping, verbose=True)
+                annotate_overlapping_spikes(spiketrains, overlapping_pairs=overlapping, verbose=self._verbose)
 
             amp_mod = []
             cons_spikes = []
@@ -1025,13 +1027,11 @@ class RecordingGenerator:
                     additive_noise = tmp_noise_rec['recordings']
 
                 # removing mean
-                print(np.mean(additive_noise, axis=1))
                 for i, m in enumerate(np.mean(additive_noise, axis=1)):
                     if not tmp_h5:
                         additive_noise[i] -= m
                     else:
                         additive_noise[i, ...] -= m
-                print(np.mean(additive_noise, axis=1))
 
                 # adding noise floor
                 for i, s in enumerate(np.std(additive_noise, axis=1)):

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -665,7 +665,7 @@ class RecordingGenerator:
                                                                                 t_start_drift, fs, self._verbose,
                                                                                 amp_mod, bursting_units, shape_mod,
                                                                                 bursting_sigmoid, chunk[0], True,
-                                                                                voltage_peaks, tempfiles[ch],))
+                                                                                voltage_peaks, dtype, tempfiles[ch],))
                     p.start()
                     threads.append(p)
                 for p in threads:
@@ -707,7 +707,7 @@ class RecordingGenerator:
                                   velocity_vector=velocity_vector, t_start_drift=t_start_drift, fs=fs, amp_mod=amp_mod,
                                   bursting_units=bursting_units, shape_mod=shape_mod, bursting_sigmoid=bursting_sigmoid,
                                   chunk_start=0 * pq.s, extract_spike_traces=True, voltage_peaks=voltage_peaks,
-                                  tmp_mearec_file=tmp_rec, verbose=self._verbose)
+                                  dtype=dtype, tmp_mearec_file=tmp_rec, verbose=self._verbose)
                 if not self._tmp_h5:
                     recordings = output_dict[ch]['rec']
                     spike_traces = output_dict[ch]['spike_traces']

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -947,7 +947,7 @@ class RecordingGenerator:
                                                                                     None, None, self._verbose,
                                                                                     None, None, False,
                                                                                     None, chunk[0], False,
-                                                                                    voltage_peaks))
+                                                                                    voltage_peaks, dtype,))
                         p.start()
                         threads.append(p)
                     for p in threads:
@@ -966,7 +966,7 @@ class RecordingGenerator:
                     # reorder this
                     chunk_convolution(ch, idxs, output_dict, spike_matrix_noise, 'none', False, None,
                                       templates_noise, cut_outs_samples, template_noise_locs, None, None, None,
-                                      self._verbose, None, None, False, None, 0 * pq.s, False, voltage_peaks)
+                                      self._verbose, None, None, False, None, 0 * pq.s, False, voltage_peaks, dtype)
                     additive_noise = output_dict[ch]['rec']
 
                 # remove mean

--- a/MEArec/generators/templategenerator.py
+++ b/MEArec/generators/templategenerator.py
@@ -45,6 +45,7 @@ class TemplateGenerator:
             if 'celltypes' in temp_dict.keys():
                 self.celltypes = temp_dict['celltypes']
             self.info = info
+            self.params = deepcopy(info)
         else:
             if cell_models_folder is None:
                 raise AttributeError("Specify cell folder!")

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -231,22 +231,22 @@ def load_templates(templates, return_h5_objects=True, verbose=False, check_suffi
     temp_dict = {}
     templates = Path(templates)
     if (templates.suffix == '.h5' or templates.suffix == '.hdf5') or (not check_suffix):
-        with h5py.File(str(templates), 'r') as F:
-            info = load_dict_from_hdf5(F, 'info/')
-            celltypes = np.array(F.get('celltypes'))
-            temp_dict['celltypes'] = np.array([c.decode('utf-8') for c in celltypes])
-            if return_h5_objects:
-                temp_dict['locations'] = F.get('locations')
-            else:
-                temp_dict['locations'] = np.array(F.get('locations'))
-            if return_h5_objects:
-                temp_dict['rotations'] = F.get('rotations')
-            else:
-                temp_dict['rotations'] = np.array(F.get('rotations'))
-            if return_h5_objects:
-                temp_dict['templates'] = F.get('templates')
-            else:
-                temp_dict['templates'] = np.array(F.get('templates'))
+        F = h5py.File(str(templates), 'r')
+        info = load_dict_from_hdf5(F, 'info/')
+        celltypes = np.array(F.get('celltypes'))
+        temp_dict['celltypes'] = np.array([c.decode('utf-8') for c in celltypes])
+        if return_h5_objects:
+            temp_dict['locations'] = F.get('locations')
+        else:
+            temp_dict['locations'] = np.array(F.get('locations'))
+        if return_h5_objects:
+            temp_dict['rotations'] = F.get('rotations')
+        else:
+            temp_dict['rotations'] = np.array(F.get('rotations'))
+        if return_h5_objects:
+            temp_dict['templates'] = F.get('templates')
+        else:
+            temp_dict['templates'] = np.array(F.get('templates'))
     else:
         raise Exception("Recordings must be an hdf5 file (.h5 or .hdf5)")
 

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -2589,7 +2589,7 @@ def convolve_drifting_templates_spiketrains(spike_id, spike_bin, template, fs, l
 def chunk_convolution(ch, idxs, output_dict, spike_matrix, modulation, drifting, drifting_units, templates,
                       cut_outs_samples, template_locs, velocity_vector, t_start_drift, fs, verbose,
                       amp_mod, bursting_units, shape_mod, bursting_sigmoid, chunk_start, extract_spike_traces,
-                      voltage_peaks, tmp_mearec_file=None):
+                      voltage_peaks, dtype, tmp_mearec_file=None):
     """
     Perform full convolution for all spike trains by chunk. Used with multiprocessing.
 
@@ -2640,12 +2640,12 @@ def chunk_convolution(ch, idxs, output_dict, spike_matrix, modulation, drifting,
     """
     final_locs = []
     final_idxs = []
-    spike_traces = np.zeros((len(spike_matrix), len(idxs)))
+    spike_traces = np.zeros((len(spike_matrix), len(idxs)), dtype=dtype)
     if len(templates.shape) == 4:
         n_elec = templates.shape[2]
     elif len(templates.shape) == 5:
         n_elec = templates.shape[3]
-    recordings = np.zeros((n_elec, len(idxs)))
+    recordings = np.zeros((n_elec, len(idxs)), dtype=dtype)
     for st, spike_bin in enumerate(spike_matrix):
         if extract_spike_traces:
             max_electrode = np.argmax(voltage_peaks[st])

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -202,7 +202,7 @@ def load_tmp_eap(templates_folder, celltypes=None, samples_per_cat=None, verbose
     return np.array(eap_list), np.array(loc_list), np.array(rot_list), np.array(cat_list, dtype=str)
 
 
-def load_templates(templates, return_h5_objects=True, verbose=False):
+def load_templates(templates, return_h5_objects=True, verbose=False, check_suffix=True):
     """
     Load generated eap templates.
 
@@ -210,6 +210,13 @@ def load_templates(templates, return_h5_objects=True, verbose=False):
     ----------
     templates : str or Path object
         templates file
+    return_h5_objects : bool
+        If True output objects are h5 objects
+    verbose : bool
+        If True output is verbose
+    check_suffix : bool
+        If True, hfdf5 suffix is checked
+
 
     Returns
     -------
@@ -223,23 +230,23 @@ def load_templates(templates, return_h5_objects=True, verbose=False):
 
     temp_dict = {}
     templates = Path(templates)
-    if templates.suffix == '.h5' or templates.suffix == '.hdf5':
-        F = h5py.File(str(templates), 'r')
-        info = load_dict_from_hdf5(F, 'info/')
-        celltypes = np.array(F.get('celltypes'))
-        temp_dict['celltypes'] = np.array([c.decode('utf-8') for c in celltypes])
-        if return_h5_objects:
-            temp_dict['locations'] = F.get('locations')
-        else:
-            temp_dict['locations'] = np.array(F.get('locations'))
-        if return_h5_objects:
-            temp_dict['rotations'] = F.get('rotations')
-        else:
-            temp_dict['rotations'] = np.array(F.get('rotations'))
-        if return_h5_objects:
-            temp_dict['templates'] = F.get('templates')
-        else:
-            temp_dict['templates'] = np.array(F.get('templates'))
+    if (templates.suffix == '.h5' or templates.suffix == '.hdf5') or (not check_suffix):
+        with h5py.File(str(templates), 'r') as F:
+            info = load_dict_from_hdf5(F, 'info/')
+            celltypes = np.array(F.get('celltypes'))
+            temp_dict['celltypes'] = np.array([c.decode('utf-8') for c in celltypes])
+            if return_h5_objects:
+                temp_dict['locations'] = F.get('locations')
+            else:
+                temp_dict['locations'] = np.array(F.get('locations'))
+            if return_h5_objects:
+                temp_dict['rotations'] = F.get('rotations')
+            else:
+                temp_dict['rotations'] = np.array(F.get('rotations'))
+            if return_h5_objects:
+                temp_dict['templates'] = F.get('templates')
+            else:
+                temp_dict['templates'] = np.array(F.get('templates'))
     else:
         raise Exception("Recordings must be an hdf5 file (.h5 or .hdf5)")
 
@@ -251,7 +258,8 @@ def load_templates(templates, return_h5_objects=True, verbose=False):
     return tempgen
 
 
-def load_recordings(recordings, return_h5_objects=True, verbose=False, load_waveforms=True, check_suffix=True):
+def load_recordings(recordings, return_h5_objects=True,
+                    load=None, load_waveforms=True, check_suffix=True,  verbose=False):
     """
     Load generated recordings.
 
@@ -261,8 +269,15 @@ def load_recordings(recordings, return_h5_objects=True, verbose=False, load_wave
         Recordings file
     return_h5_objects : bool
         If True output objects are h5 objects
+    load : list
+        List of fields to be loaded (('recordings', 'channel_positions', 'voltage_peaks', 'spiketrains',
+                                       'timestamps', 'spike_traces', 'templates'))
     load_waveforms : bool
-        If True waveforms are loaded
+        If True waveforms are loaded to spiketrains
+    verbose : bool
+        If True output is verbose
+    check_suffix : bool
+        If True, hfdf5 suffix is checked
 
     Returns
     -------
@@ -274,58 +289,63 @@ def load_recordings(recordings, return_h5_objects=True, verbose=False, load_wave
     if verbose:
         print("Loading recordings...")
 
+    if load is None:
+        load = ['recordings', 'channel_positions', 'voltage_peaks', 'spiketrains', 'timestamps',
+                'spike_traces', 'templates']
+    else:
+        assert isinstance(load, list), "'load' should be a list with strings of what to be loaded " \
+                                       "('recordings', 'channel_positions', 'voltge_peaks', 'spiketrains', " \
+                                       "'timestamps', 'spike_traces', 'templates')"
+
     rec_dict = {}
     recordings = Path(recordings)
     if (recordings.suffix == '.h5' or recordings.suffix == '.hdf5') or (not check_suffix):
         F = h5py.File(str(recordings), 'r')
         info = load_dict_from_hdf5(F, 'info/')
-        if F.get('voltage_peaks') is not None:
+        if F.get('voltage_peaks') is not None and 'voltage_peaks' in load:
             if return_h5_objects:
                 rec_dict['voltage_peaks'] = F.get('voltage_peaks')
             else:
                 rec_dict['voltage_peaks'] = np.array(F.get('voltage_peaks'))
-        if F.get('channel_positions') is not None:
+        if F.get('channel_positions') is not None and 'channel_positions' in load:
             if return_h5_objects:
                 rec_dict['channel_positions'] = F.get('channel_positions')
             else:
                 rec_dict['channel_positions'] = np.array(F.get('channel_positions'))
-        if F.get('recordings') is not None:
+        if F.get('recordings') is not None and 'recordings' in load:
             if return_h5_objects:
                 rec_dict['recordings'] = F.get('recordings')
             else:
                 rec_dict['recordings'] = np.array(F.get('recordings'))
-        if F.get('spike_traces') is not None:
+        if F.get('spike_traces') is not None and 'spike_traces' in load:
             if return_h5_objects:
                 rec_dict['spike_traces'] = F.get('spike_traces')
             else:
                 rec_dict['spike_traces'] = np.array(F.get('spike_traces'))
-        if F.get('templates') is not None:
+        if F.get('templates') is not None and 'templates' in load:
             if return_h5_objects:
                 rec_dict['templates'] = F.get('templates')
             else:
                 rec_dict['templates'] = np.array(F.get('templates'))
-        if F.get('template_locations') is not None:
-            if return_h5_objects:
-                rec_dict['template_locations'] = F.get('template_locations')
-            else:
-                rec_dict['template_locations'] = np.array(F.get('template_locations'))
-        if F.get('template_rotations') is not None:
-            if return_h5_objects:
-                rec_dict['template_rotations'] = F.get('template_rotations')
-            else:
-                rec_dict['template_rotations'] = np.array(F.get('template_rotations'))
-        if F.get('template_celltypes') is not None:
-            if return_h5_objects:
-                rec_dict['template_celltypes'] = F.get('template_celltypes')
-            else:
+            if F.get('template_locations') is not None:
+                if return_h5_objects:
+                    rec_dict['template_locations'] = F.get('template_locations')
+                else:
+                    rec_dict['template_locations'] = np.array(F.get('template_locations'))
+            if F.get('template_rotations') is not None:
+                if return_h5_objects:
+                    rec_dict['template_rotations'] = F.get('template_rotations')
+                else:
+                    rec_dict['template_rotations'] = np.array(F.get('template_rotations'))
+            if F.get('template_celltypes') is not None:
                 celltypes = np.array(([n.decode() for n in F.get('template_celltypes')]))
                 rec_dict['template_celltypes'] = np.array(celltypes)
-        if F.get('timestamps') is not None:
+        if F.get('timestamps') is not None and 'timestamps' in load:
             if return_h5_objects:
                 rec_dict['timestamps'] = F.get('timestamps')
             else:
-                rec_dict['timestamps'] = np.array(F.get('timestamps'))
-        if F.get('spiketrains') is not None:
+                rec_dict['timestamps'] = np.array(F.get('timestamps')) * pq.s
+        if F.get('spiketrains') is not None and 'spiketrains' in load:
             spiketrains = []
             sorted_units = sorted([int(u) for u in F.get('spiketrains/')])
             for unit in sorted_units:
@@ -410,36 +430,35 @@ def save_recording_generator(recgen, filename=None, verbose=True):
     if not filename.parent.is_dir():
         os.makedirs(str(filename.parent))
     if filename.suffix == '.h5' or filename.suffix == '.hdf5':
-        F = h5py.File(filename, 'w')
-        save_dict_to_hdf5(recgen.info, F, 'info/')
-        if len(recgen.voltage_peaks) > 0:
-            F.create_dataset('voltage_peaks', data=recgen.voltage_peaks)
-        if len(recgen.channel_positions) > 0:
-            F.create_dataset('channel_positions', data=recgen.channel_positions)
-        if len(recgen.recordings) > 0:
-            F.create_dataset('recordings', data=recgen.recordings)
-        if len(recgen.spike_traces) > 0:
-            F.create_dataset('spike_traces', data=recgen.spike_traces)
-        if len(recgen.spiketrains) > 0:
-            for ii in range(len(recgen.spiketrains)):
-                st = recgen.spiketrains[ii]
-                F.create_dataset('spiketrains/{}/times'.format(ii), data=st.times.rescale('s').magnitude)
-                F.create_dataset('spiketrains/{}/t_stop'.format(ii), data=st.t_stop)
-                if st.waveforms is not None:
-                    F.create_dataset('spiketrains/{}/waveforms'.format(ii), data=st.waveforms)
-                save_dict_to_hdf5(st.annotations, F, 'spiketrains/{}/annotations/'.format(ii))
-        if len(recgen.templates) > 0:
-            F.create_dataset('templates', data=recgen.templates)
-        if len(recgen.template_locations) > 0:
-            F.create_dataset('template_locations', data=recgen.template_locations)
-        if len(recgen.template_rotations) > 0:
-            F.create_dataset('template_rotations', data=recgen.template_rotations)
-        if len(recgen.template_celltypes) > 0:
-            celltypes = [n.encode("ascii", "ignore") for n in recgen.template_celltypes]
-            F.create_dataset('template_celltypes', data=celltypes)
-        if len(recgen.timestamps) > 0:
-            F.create_dataset('timestamps', data=recgen.timestamps)
-        F.close()
+        with h5py.File(filename, 'w') as F:
+            save_dict_to_hdf5(recgen.info, F, 'info/')
+            if len(recgen.voltage_peaks) > 0:
+                F.create_dataset('voltage_peaks', data=recgen.voltage_peaks)
+            if len(recgen.channel_positions) > 0:
+                F.create_dataset('channel_positions', data=recgen.channel_positions)
+            if len(recgen.recordings) > 0:
+                F.create_dataset('recordings', data=recgen.recordings)
+            if len(recgen.spike_traces) > 0:
+                F.create_dataset('spike_traces', data=recgen.spike_traces)
+            if len(recgen.spiketrains) > 0:
+                for ii in range(len(recgen.spiketrains)):
+                    st = recgen.spiketrains[ii]
+                    F.create_dataset('spiketrains/{}/times'.format(ii), data=st.times.rescale('s').magnitude)
+                    F.create_dataset('spiketrains/{}/t_stop'.format(ii), data=st.t_stop)
+                    if st.waveforms is not None:
+                        F.create_dataset('spiketrains/{}/waveforms'.format(ii), data=st.waveforms)
+                    save_dict_to_hdf5(st.annotations, F, 'spiketrains/{}/annotations/'.format(ii))
+            if len(recgen.templates) > 0:
+                F.create_dataset('templates', data=recgen.templates)
+            if len(recgen.template_locations) > 0:
+                F.create_dataset('template_locations', data=recgen.template_locations)
+            if len(recgen.template_rotations) > 0:
+                F.create_dataset('template_rotations', data=recgen.template_rotations)
+            if len(recgen.template_celltypes) > 0:
+                celltypes = [n.encode("ascii", "ignore") for n in recgen.template_celltypes]
+                F.create_dataset('template_celltypes', data=celltypes)
+            if len(recgen.timestamps) > 0:
+                F.create_dataset('timestamps', data=recgen.timestamps)
         if verbose:
             print('\nSaved recordings in', filename, '\n')
     else:
@@ -2649,7 +2668,8 @@ def chunk_convolution(ch, idxs, output_dict, spike_matrix, modulation, drifting,
     """
     final_locs = []
     final_idxs = []
-    spike_traces = np.zeros((len(spike_matrix), len(idxs)), dtype=dtype)
+    if extract_spike_traces:
+        spike_traces = np.zeros((len(spike_matrix), len(idxs)), dtype=dtype)
     if len(templates.shape) == 4:
         n_elec = templates.shape[2]
     elif len(templates.shape) == 5:
@@ -2863,19 +2883,22 @@ def chunk_convolution(ch, idxs, output_dict, spike_matrix, modulation, drifting,
             if verbose:
                 print('Dumping on tmp file:', tmp_mearec_file.filename)
             tmp_mearec_file['recordings'][:, :len(idxs)] = recordings
-            tmp_mearec_file['spike_traces'][:, :len(idxs)] = spike_traces
+            if extract_spike_traces:
+                tmp_mearec_file['spike_traces'][:, :len(idxs)] = spike_traces
         else:
             assert isinstance(tmp_mearec_file, (str, Path))
             with h5py.File(tmp_mearec_file) as f:
                 if verbose:
                     print('Dumping on tmp file:', f.filename)
                 f.create_dataset('recordings', data=recordings)
-                f.create_dataset('spike_traces', data=spike_traces)
+                if extract_spike_traces:
+                    f.create_dataset('spike_traces', data=spike_traces)
         return_dict['idxs'] = idxs
     else:
         return_dict['rec'] = recordings
         return_dict['idxs'] = idxs
-        return_dict['spike_traces'] = spike_traces
+        if extract_spike_traces:
+            return_dict['spike_traces'] = spike_traces
     return_dict['final_locs'] = final_locs
     return_dict['final_idxs'] = final_idxs
     output_dict[ch] = return_dict

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -202,7 +202,7 @@ def load_tmp_eap(templates_folder, celltypes=None, samples_per_cat=None, verbose
     return np.array(eap_list), np.array(loc_list), np.array(rot_list), np.array(cat_list, dtype=str)
 
 
-def load_templates(templates, return_h5_objects=False, verbose=False):
+def load_templates(templates, return_h5_objects=True, verbose=False):
     """
     Load generated eap templates.
 
@@ -251,7 +251,7 @@ def load_templates(templates, return_h5_objects=False, verbose=False):
     return tempgen
 
 
-def load_recordings(recordings, return_h5_objects=False, verbose=False, load_waveforms=True, check_suffix=True):
+def load_recordings(recordings, return_h5_objects=True, verbose=False, load_waveforms=True, check_suffix=True):
     """
     Load generated recordings.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,7 +25,7 @@ Module :mod:`MEArec.generators`
 
 
 Module :mod:`MEArec.generation_tools`
-===============================
+=====================================
 .. automodule:: generation_tools
 
     function :class:`gen_templates`

--- a/figures/figure3.py
+++ b/figures/figure3.py
@@ -58,9 +58,9 @@ if plot_templates:
     npix_templates = 'data/templates/templates_100_Neuropixels-128.h5'
     sqmea_templates = 'data/templates/templates_100_SqMEA-10-15.h5'
 
-    tempgen_t = mr.load_templates(nexus_templates)
-    tempgen_np = mr.load_templates(npix_templates)
-    tempgen_sq = mr.load_templates(sqmea_templates)
+    tempgen_t = mr.load_templates(nexus_templates, return_h5_objects=False)
+    tempgen_np = mr.load_templates(npix_templates, return_h5_objects=False)
+    tempgen_sq = mr.load_templates(sqmea_templates, return_h5_objects=False)
 
     templates_t = tempgen_t.templates[1000]
     templates_np = tempgen_np.templates[1000]
@@ -100,9 +100,9 @@ if plot_recs:
     npix_rec = 'data/recordings/recordings_60cells_Neuropixels-128_30.0_10.0uV.h5'
     sqmea_rec = 'data/recordings/recordings_50cells_SqMEA-10-15_30.0_10.0uV.h5'
 
-    recgen_t = mr.load_recordings(nexus_rec)
-    recgen_np = mr.load_recordings(npix_rec)
-    recgen_sq = mr.load_recordings(sqmea_rec)
+    recgen_t = mr.load_recordings(nexus_rec, return_h5_objects=False)
+    recgen_np = mr.load_recordings(npix_rec, return_h5_objects=False)
+    recgen_sq = mr.load_recordings(sqmea_rec, return_h5_objects=False)
 
     mr.plot_recordings(recgen_t, ax=ax31, start_time=0, end_time=seconds, lw=0.2)
     mr.plot_recordings(recgen_np, ax=ax32, start_time=0, end_time=seconds, lw=0.2, vscale=150)

--- a/figures/figure4.py
+++ b/figures/figure4.py
@@ -68,7 +68,7 @@ if plot_mod:
 
 # Load recordings data
 tetrode_rec = 'data/recordings/recordings_6cells_tetrode_30.0_10.0uV.h5'
-recgen_noburst = mr.load_recordings(tetrode_rec)
+recgen_noburst = mr.load_recordings(tetrode_rec, return_h5_objects=False)
 
 if plot_burst:
     templates = recgen_noburst.templates
@@ -116,7 +116,7 @@ if plot_burst:
     ax32 = fig3.add_subplot(gs[1:3, :])
     ax33 = fig3.add_subplot(gs[3:, :])
 
-    ts = recgen_noburst.timestamps * pq.ms
+    ts = recgen_noburst.timestamps
     spiketrain = recgen_noburst.spiketrains[template_id].times
     modulations = mod_array[template_id]
     cut_out_temp = recgen_noburst.info['templates']['cut_out']

--- a/figures/figure5.py
+++ b/figures/figure5.py
@@ -11,7 +11,7 @@ plt.show()
 
 template_file = 'data/templates/templates_100_Neuronexus-32.h5'
 
-tempgen = mr.load_templates(template_file)
+tempgen = mr.load_templates(template_file, return_h5_objects=False)
 
 recgen_random = mr.gen_recordings(tempgen=tempgen, params='figure5_params.yaml')
 params = recgen_random.params

--- a/figures/figure6.py
+++ b/figures/figure6.py
@@ -11,7 +11,7 @@ plt.ion()
 plt.show()
 
 template_file = 'data/templates/templates_30_Neuronexus-32_drift.h5'
-tempgen = mr.load_templates(template_file)
+tempgen = mr.load_templates(template_file, return_h5_objects=False)
 
 # select one drifting template
 template_id = 341

--- a/figures/figure7.py
+++ b/figures/figure7.py
@@ -1,7 +1,7 @@
 import MEArec as mr
 import matplotlib.pylab as plt
 import matplotlib.gridspec as gridspec
-from copy import deepcopy
+from copy import deepcopy, copy
 import scipy.signal as ss
 import scipy.stats as stat
 from plotting_conventions import *
@@ -14,9 +14,8 @@ plt.ion()
 plt.show()
 
 template_file = 'data/templates/templates_300_tetrode_minamp0.h5'
-tempgen = mr.load_templates(template_file)
-
-recgen_u = mr.gen_recordings(tempgen=tempgen, params='figure7_params.yaml')
+tempgen = mr.load_templates(template_file, return_h5_objects=False)
+recgen_u = mr.gen_recordings(tempgen=tempgen, params='figure7_params.yaml', tmp_h5=False)
 
 recgen_dc = deepcopy(recgen_u)
 recgen_dc.params['recordings']['noise_mode'] = 'distance-correlated'

--- a/figures/figure8.py
+++ b/figures/figure8.py
@@ -14,7 +14,7 @@ plt.show()
 noise_levels = [30, 20, 10, 5]
 
 template_file = 'data/templates/templates_100_Neuronexus-32.h5'
-tempgen = mr.load_templates(template_file)
+tempgen = mr.load_templates(template_file, return_h5_objects=False)
 
 with open('figure8_params.yaml', 'r') as f:
     params = yaml.load(f)
@@ -57,7 +57,7 @@ ax_noise.text(x_lim[0] + 0.01 * ts_lim, np.min(y_lim) + 0.05 * np.abs(np.min(y_l
 drift_velocities = [60, 30, 10]
 
 template_drift_file = 'data/templates/templates_30_Neuronexus-32_drift.h5'
-tempgen_drift = mr.load_templates(template_drift_file)
+tempgen_drift = mr.load_templates(template_drift_file, return_h5_objects=False)
 
 params['recordings']['noise_level'] = 10
 params['spiketrains']['duration'] = 60


### PR DESCRIPTION
- set dtype in `chunk_convolution` tmp recording creation
- pass to `convolve_templates_spiketrains` the `recordings` object created in `chunk_convolution` (without duplicating them)