### PR TITLE
fixed bug of generating templates on Win

### DIFF
--- a/MEArec/simulate_cells.py
+++ b/MEArec/simulate_cells.py
@@ -66,9 +66,13 @@ def compile_all_mechanisms(cell_folder, verbose=False):
     for nrn in neurons:
         for nmodl in glob(join(nrn, 'mechanisms', '*.mod')):
             while not os.path.isfile(join(cell_folder, 'mods', os.path.split(nmodl)[-1])):
+            	if sys.platform == 'win32':
+            		_command = 'copy'
+            	else:
+            		_command = 'cp'
                 if verbose:
-                    print('cp {} {}'.format(nmodl, join(cell_folder, 'mods')))
-                os.system('cp {} {}'.format(nmodl, join(cell_folder, 'mods')))
+                    print('{} {} {}'.format(_command, nmodl, join(cell_folder, 'mods')))
+                os.system('{} {} {}'.format(_command, nmodl, join(cell_folder, 'mods')))
     starting_dir = os.getcwd()
     os.chdir(join(cell_folder, 'mods'))
     os.system('nrnivmodl')


### PR DESCRIPTION
In `MEArec/simulate_cells.py', the command is updated to be able to run on both Unix and Windows.