### PR TITLE
Allow users to specify bursting params for each unit separately

### DIFF
--- a/MEArec/default_params/recordings_params.yaml
+++ b/MEArec/default_params/recordings_params.yaml
@@ -61,7 +61,8 @@ recordings:
     # electrode (each electrode is modulated separately)]
   sdrand:  0.05 # standard deviation of gaussian modulation
   bursting: False # if True, spikes are modulated in amplitude depending on the isi and in shape (if shape_mod is True)
-  exp_decay: 0.2 # with bursting modulation experimental decay in aplitude between consecutive spikes
+  bursting_units: None # if not None, list to indicate which units should br bursting
+  exp_decay: 0.2 # with bursting modulation experimental decay in amplitude between consecutive spikes
   n_burst_spikes: 10 # max number of 'bursting' consecutive spikes
   max_burst_duration: 100 # duration in ms of maximum burst modulation
   shape_mod: False # if True waveforms are modulated in shape with a low pass filter depending on the isi

--- a/MEArec/default_params/recordings_params.yaml
+++ b/MEArec/default_params/recordings_params.yaml
@@ -61,7 +61,7 @@ recordings:
     # electrode (each electrode is modulated separately)]
   sdrand:  0.05 # standard deviation of gaussian modulation
   bursting: False # if True, spikes are modulated in amplitude depending on the isi and in shape (if shape_mod is True)
-  bursting_units: None # if not None, list to indicate which units should br bursting
+  bursting_units: null # if not None, list to indicate which units should br bursting
   exp_decay: 0.2 # with bursting modulation experimental decay in amplitude between consecutive spikes
   n_burst_spikes: 10 # max number of 'bursting' consecutive spikes
   max_burst_duration: 100 # duration in ms of maximum burst modulation

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -420,7 +420,6 @@ class RecordingGenerator:
             n_burst_spikes = None
             max_burst_duration = None
             shape_stretch = None
-            n_bursting = None
             bursting_units = []
 
         chunk_duration = params['recordings'].get('chunk_duration', 0) * pq.s
@@ -846,11 +845,6 @@ class RecordingGenerator:
                 drifting_units = np.random.permutation(n_neurons)[:n_drifting]
             else:
                 drifting_units = []
-
-            # if bursting:
-            #     bursting_units = np.random.permutation(n_neurons)[:n_bursting]
-            # else:
-            #     bursting_units = []
 
             if modulation == 'template':
                 if verbose_1:

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -426,20 +426,11 @@ class RecordingGenerator:
                     assert len(rec_params['max_burst_duration']) == n_bursting, \
                         "'max_burst_duration' should have the same length as the number of bursting units"
                     params['recordings']['max_burst_duration'] = rec_params['max_burst_duration']
-            max_burst_duration = params['recordings']['max_burst_duration']
+            max_burst_duration = [m * pq.ms for m in params['recordings']['max_burst_duration']]
 
             if shape_mod:
                 if 'shape_stretch' not in rec_params.keys():
-                    params['recordings']['shape_stretch'] = [30] * n_bursting
-                else:
-                    if not isinstance(rec_params['shape_stretch'], list):
-                        assert isinstance(rec_params['shape_stretch'], (float, int, np.integer)), \
-                            "'shape_stretch' can be list or scalar"
-                        params['recordings']['shape_stretch'] = [rec_params['shape_stretch']] * n_bursting
-                    else:
-                        assert len(rec_params['shape_stretch']) == n_bursting, \
-                            "'shape_stretch' should have the same length as the number of bursting units"
-                        params['recordings']['shape_stretch'] = rec_params['shape_stretch']
+                    params['recordings']['shape_stretch'] = 30
                 shape_stretch = params['recordings']['shape_stretch']
                 if verbose_1:
                     print('Bursting with modulation sigmoid: ', shape_stretch)

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -853,8 +853,9 @@ class RecordingGenerator:
                     if bursting and i_s in bursting_units:
                         if verbose_1:
                             print('Bursting unit: ', i_s)
+                        exp_decay_idx = list(bursting_units).index(i_s)
                         amp, cons = compute_modulation(st, sdrand=sdrand,
-                                                       n_spikes=n_burst_spikes, exp=exp_decay[i_s],
+                                                       n_spikes=n_burst_spikes, exp=exp_decay[exp_decay_idx],
                                                        max_burst_duration=max_burst_duration)
 
                         amp_mod.append(amp)
@@ -873,8 +874,9 @@ class RecordingGenerator:
                     if bursting and i_s in bursting_units:
                         if verbose_1:
                             print('Bursting unit: ', i_s)
+                        exp_decay_idx = list(bursting_units).index(i_s)
                         amp, cons = compute_modulation(st, n_el=n_elec, mrand=mrand, sdrand=sdrand,
-                                                       n_spikes=n_burst_spikes, exp=exp_decay[i_s],
+                                                       n_spikes=n_burst_spikes, exp=exp_decay[exp_decay_idx],
                                                        max_burst_duration=max_burst_duration)
                         amp_mod.append(amp)
 

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -380,24 +380,26 @@ class RecordingGenerator:
             max_burst_duration = params['recordings']['max_burst_duration'] * pq.ms
 
             if 'bursting_units' not in rec_params.keys():
+                rec_params['bursting_units'] = None
+
+            if rec_params['bursting_units'] is not None:
+                assert np.all([b < n_neurons for b in rec_params['bursting_units']]), \
+                    "'bursting_units' ids should be lower than the number of neurons"
+                n_bursting = len(rec_params['bursting_units'])
+                bursting_units = rec_params['bursting_units']
+            else:
                 if rec_params['n_bursting'] is None:
                     n_bursting = n_neurons
                     bursting_units = np.arange(n_neurons)
                 else:
                     n_bursting = rec_params['n_bursting']
                     bursting_units = np.random.permutation(n_neurons)[:n_bursting]
-            else:
-                assert np.all([b < n_neurons for b in rec_params['bursting_units']]), "'bursting_units' ids should " \
-                                                                                      "be lower than the number of" \
-                                                                                      " neurons"
-                n_bursting = len(rec_params['bursting_units'])
-                bursting_units = rec_params['bursting_units']
 
             if 'exp_decay' not in rec_params.keys():
                 params['recordings']['exp_decay'] = [0.2] * n_bursting
             else:
                 if not isinstance(rec_params['exp_decay'], list):
-                    assert  isinstance(rec_params['exp_decay'], float), "'exp_decay' can be list or float"
+                    assert isinstance(rec_params['exp_decay'], float), "'exp_decay' can be list or float"
                     params['recordings']['exp_decay'] = [rec_params['exp_decay']] * n_bursting
                 else:
                     assert len(rec_params['exp_decay']) == n_bursting, "'exp_decay' should have the same length as " \
@@ -692,7 +694,7 @@ class RecordingGenerator:
                                                                 overlap_threshold=overlap_threshold,
                                                                 verbose=verbose_2)
 
-                    if not np.any('U' in  selected_cat):
+                    if not np.any('U' in selected_cat):
                         assert selected_cat.count('E') == n_exc and selected_cat.count('I') == n_inh
                         # Reorder templates according to E-I types
                         reordered_idx_cells = np.array(idxs_cells)[np.argsort(selected_cat)]
@@ -1059,7 +1061,7 @@ class RecordingGenerator:
                 # adding noise floor
                 for i, s in enumerate(np.std(additive_noise, axis=0)):
                     additive_noise[:, i] += far_neurons_noise_floor * s * \
-                                                np.random.randn(additive_noise.shape[0])
+                                            np.random.randn(additive_noise.shape[0])
                 # scaling noise
                 noise_scale = noise_level / np.std(additive_noise, axis=0)
                 if verbose_1:
@@ -1223,7 +1225,6 @@ def run_several_chunks(func, chunk_indexes, fs, timestamps, args, n_jobs, tmp_mo
     arg_tasks = []
     karg_tasks = []
     for ch, (i_start, i_stop) in enumerate(chunk_indexes):
-
         chunk_start = (i_start / fs).rescale('s')
 
         arg_task = (ch, i_start, i_stop, chunk_start,) + args

--- a/MEArec/tests/test_generators.py
+++ b/MEArec/tests/test_generators.py
@@ -319,7 +319,7 @@ class TestGenerators(unittest.TestCase):
         rec_params['recordings']['exp_decay'] = [0.1, 0.15, 0.2]
         rec_params['recordings']['max_burst_duration'] = [50, 100, 150]
         rec_params['recordings']['n_burst_spikes'] = [5, 10, 15]
-        rec_params['recordings']['shape_stretch'] = [10, 20, 30]
+        rec_params['recordings']['shape_stretch'] = 10
 
         recgen_burst = mr.gen_recordings(params=rec_params, tempgen=self.tempgen, verbose=False)
         recgen_burst.extract_waveforms()
@@ -340,7 +340,7 @@ class TestGenerators(unittest.TestCase):
         rec_params['recordings']['exp_decay'] = [0.1, 0.15]
         rec_params['recordings']['max_burst_duration'] = [50, 100]
         rec_params['recordings']['n_burst_spikes'] = [10, 15]
-        rec_params['recordings']['shape_stretch'] = [20, 30]
+        rec_params['recordings']['shape_stretch'] = 20
 
         recgen_burst = mr.gen_recordings(params=rec_params, tempgen=self.tempgen, verbose=False)
         recgen_burst.extract_waveforms()

--- a/MEArec/tests/test_generators.py
+++ b/MEArec/tests/test_generators.py
@@ -293,6 +293,71 @@ class TestGenerators(unittest.TestCase):
         assert recgen_burst.spike_traces.shape[1] == n_neurons
         del recgen_burst
 
+    def test_gen_recordings_multiple_bursting_modulation(self):
+        print('Test recording generation - multiple bursting modulation')
+        rates = [10, 20, 30]
+        types = ['E', 'E', 'I']
+        num_chan = self.num_chan
+        n_neurons = len(rates)
+
+        rec_params = mr.get_default_recordings_params()
+
+        rec_params['spiketrains']['rates'] = rates
+        rec_params['spiketrains']['types'] = types
+        rec_params['spiketrains']['duration'] = 3
+        n_jitter = 4
+        rec_params['templates']['n_jitters'] = n_jitter
+        rec_params['recordings']['modulation'] = 'electrode'
+        rec_params['recordings']['bursting'] = True
+        rec_params['recordings']['shape_mod'] = True
+        rec_params['recordings']['sync_rate'] = 0.2
+        rec_params['recordings']['overlap'] = True
+        rec_params['recordings']['extract_waveforms'] = True
+        rec_params['templates']['min_dist'] = 1
+        rec_params['templates']['min_amp'] = 0
+
+        rec_params['recordings']['exp_decay'] = [0.1, 0.15, 0.2]
+        rec_params['recordings']['max_burst_duration'] = [50, 100, 150]
+        rec_params['recordings']['n_burst_spikes'] = [5, 10, 15]
+        rec_params['recordings']['shape_stretch'] = [10, 20, 30]
+
+        recgen_burst = mr.gen_recordings(params=rec_params, tempgen=self.tempgen, verbose=False)
+        recgen_burst.extract_waveforms()
+
+        assert recgen_burst.recordings.shape[1] == num_chan
+        assert len(recgen_burst.spiketrains) == n_neurons
+        assert recgen_burst.channel_positions.shape == (num_chan, 3)
+        assert recgen_burst.templates.shape[:3] == (n_neurons, n_jitter, num_chan)
+        assert recgen_burst.voltage_peaks.shape == (n_neurons, num_chan)
+        assert recgen_burst.spike_traces.shape[1] == n_neurons
+
+        for st in recgen_burst.spiketrains:
+            assert st.annotations["bursting"]
+        del recgen_burst
+
+        rec_params['recordings']['modulation'] = 'template'
+        rec_params['recordings']['bursting_units'] = [1, 2]
+        rec_params['recordings']['exp_decay'] = [0.1, 0.15]
+        rec_params['recordings']['max_burst_duration'] = [50, 100]
+        rec_params['recordings']['n_burst_spikes'] = [10, 15]
+        rec_params['recordings']['shape_stretch'] = [20, 30]
+
+        recgen_burst = mr.gen_recordings(params=rec_params, tempgen=self.tempgen, verbose=False)
+        recgen_burst.extract_waveforms()
+
+        assert recgen_burst.recordings.shape[1] == num_chan
+        assert len(recgen_burst.spiketrains) == n_neurons
+        assert recgen_burst.channel_positions.shape == (num_chan, 3)
+        assert recgen_burst.templates.shape[:3] == (n_neurons, n_jitter, num_chan)
+        assert recgen_burst.voltage_peaks.shape == (n_neurons, num_chan)
+        assert recgen_burst.spike_traces.shape[1] == n_neurons
+        for i, st in enumerate(recgen_burst.spiketrains):
+            if i in rec_params['recordings']['bursting_units']:
+                assert st.annotations["bursting"]
+            else:
+                assert not st.annotations["bursting"]
+        del recgen_burst
+
     def test_gen_recordings_noise(self):
         print('Test recording generation - noise')
         ne = 0

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -623,9 +623,9 @@ def recursively_load_dict_contents_from_group(h5file, path):
     for key, item in h5file[path].items():
         if isinstance(item, h5py._hl.dataset.Dataset):
             # handle bytes strings
-            try:
+            if isinstance(item[()], bytes):
                 ans[key] = item[()].decode()
-            except (UnicodeDecodeError, AttributeError):
+            else:
                 ans[key] = item[()]
         elif isinstance(item, h5py._hl.group.Group):
             ans[key] = recursively_load_dict_contents_from_group(h5file, path + key + '/')

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -622,7 +622,11 @@ def recursively_load_dict_contents_from_group(h5file, path):
     ans = {}
     for key, item in h5file[path].items():
         if isinstance(item, h5py._hl.dataset.Dataset):
-            ans[key] = item[()]
+            # handle bytes strings
+            try:
+                ans[key] = item[()].decode()
+            except (UnicodeDecodeError, AttributeError):
+                ans[key] = item[()]
         elif isinstance(item, h5py._hl.group.Group):
             ans[key] = recursively_load_dict_contents_from_group(h5file, path + key + '/')
     return clean_dict(ans)

--- a/notebooks/generate_recordings_with_varying_bursting_modulation.ipynb
+++ b/notebooks/generate_recordings_with_varying_bursting_modulation.ipynb
@@ -1,0 +1,297 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate recordings with varying bursting modulation\n",
+    "\n",
+    "In this notebook, we will show how to use custom spike trains as input to the simulation. \n",
+    "We will use simple spike trains, but the user could use network simulations (e.g. using BRIAN or NEST)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import MEArec as mr\n",
+    "import matplotlib.pyplot as plt\n",
+    "import neo\n",
+    "import quantities as pq\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import numpy as np\n",
+    "%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate custom spike trains\n",
+    "\n",
+    "Let's generate 4 custom spike trains: \n",
+    "- 2 bursting neurons as excitatory cells\n",
+    "- 2 constant neurons as inhibitory cells\n",
+    "\n",
+    "We need to create a list of `neo.SpikeTrain` objects. We can annotate the spike trains with the `cell_type` keyword to tell the simulator whether a cell is excitatory (E) or inhibitory (I)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "duration = 10  # s\n",
+    "t_start = 0\n",
+    "burst_duration = 0.5\n",
+    "n_spikes_per_burst = 5\n",
+    "inter_burst = 2\n",
+    "\n",
+    "spike_times = []\n",
+    "cell_types = []\n",
+    "for i in range(2):\n",
+    "    if i == 0:        \n",
+    "        burst_start = 0.1\n",
+    "    else:\n",
+    "        burst_start = 0.7\n",
+    "    st = np.array([])\n",
+    "    while burst_start < duration - burst_duration:\n",
+    "        burst = np.linspace(burst_start, burst_start + burst_duration, n_spikes_per_burst)\n",
+    "        st = np.concatenate((st, burst))\n",
+    "        burst_start = burst_start + burst_duration + inter_burst\n",
+    "    spike_times.append(st)\n",
+    "    cell_types.append('E')\n",
+    "    \n",
+    "for i in range(2):\n",
+    "    if i == 0:\n",
+    "        spike_train_start = 0.1\n",
+    "        spike_train_stop = duration - 0.2\n",
+    "    else:\n",
+    "        spike_train_start = 0.25\n",
+    "        spike_train_stop = duration - 0.1\n",
+    "    st = np.linspace(spike_train_start, spike_train_stop, 20)\n",
+    "    spike_times.append(st)\n",
+    "    cell_types.append('I')\n",
+    "    \n",
+    "# create neo spiketrains\n",
+    "spike_trains = []\n",
+    "for i, st in enumerate(spike_times):\n",
+    "    spiketrain = neo.SpikeTrain(times=st * pq.s, t_start=t_start*pq.s, t_stop=duration*pq.s)\n",
+    "    spiketrain.annotate(cell_type=cell_types[i])\n",
+    "    spike_trains.append(spiketrain)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create SpikeTrainGenerator object\n",
+    "\n",
+    "Now we need to create a MEArec `SpikeTrainGenerator` object, which will be used in the recordings generation phase. We can also use the MEArec API to plot the spike trains."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spgen = mr.SpikeTrainGenerator(spiketrains=spike_trains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = mr.plot_rasters(spgen.spiketrains, cell_type=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate templates"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's now generate a few templates on a tetrode to build our recordings. If you have already simulated the templates or you have others, you can skip this section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template_filename = Path('templates_tetrodes.h5')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template_params = mr.get_default_templates_params()\n",
+    "cell_folder = mr.get_default_cell_models_folder()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template_params['probe'] = 'tetrode'\n",
+    "template_params['n'] = 5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tempgen = mr.gen_templates(cell_models_folder=cell_folder, params=template_params, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mr.save_template_generator(tempgen, template_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Generate recordings\n",
+    "\n",
+    "We have to load the default parameters, so we can modify some of them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "template_filename = 'templates_tetrodes.h5'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rec_params = mr.get_default_recordings_params()\n",
+    "rec_params['recordings']['noise_level'] = 5\n",
+    "rec_params['recordings']['filter'] = False\n",
+    "rec_params['recordings']['bursting'] = True\n",
+    "rec_params['recordings']['exp_decay'] = [0.1, 0.7]\n",
+    "rec_params['recordings']['max_burst_duration'] = 800\n",
+    "rec_params['recordings']['bursting_units'] = [0, 1]\n",
+    "rec_params['templates']['min_dist'] = 5\n",
+    "rec_params[\"templates\"][\"min_amp\"] = 100\n",
+    "rec_params[\"templates\"][\"max_amp\"] = 150"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "recgen = mr.gen_recordings(params=rec_params, spgen=spgen, templates=template_filename, verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mr.plot_recordings(recgen, overlay_templates=False, lw=0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spike_traces = recgen.spike_traces"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spike_traces.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(spike_traces)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/generate_recordings_with_varying_bursting_modulation.ipynb
+++ b/notebooks/generate_recordings_with_varying_bursting_modulation.ipynb
@@ -236,32 +236,6 @@
    "source": [
     "spike_traces = recgen.spike_traces"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spike_traces.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
-    "plt.plot(spike_traces)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Add the possibility to specify `exp_decay` for each bursing unit separately
- Added `bursting_units` as recording parameter to specify which unit id will be bursting
- Upgrade for `h5py>3`