### PR TITLE
Additional smoothing step for templates

### DIFF
--- a/MEArec/default_params/recordings_params.yaml
+++ b/MEArec/default_params/recordings_params.yaml
@@ -46,6 +46,8 @@ templates:
   n_jitters: 10 # number of temporal jittered copies for each eap
   upsample: 8 # upsampling factor to extract jittered copies
   pad_len: [3, 3] # padding of templates in ms
+  smooth_percent: 0.5 # percent of pad_len used to smooth with sigmoid. If 0, no extra smoothing is performed
+  smooth_strength: 1 # exponent of sigmoid function for smoothing 
 
 recordings:
   fs: null # sampling frequency in Hz (if null it is computed form the templates)


### PR DESCRIPTION
Fixes https://github.com/alejoe91/MEArec/issues/109

After the jittering step, the initial and final sample of the template could be different than zero due to re-interpolation. 
An additional smoothing step with a "sigmoid-like" window is added to make sure that sedges are smooth before convolution.

Two additional params are added:
* `smooth_percent`: percent of pad lenght (default 3ms) to use to smooth the edges (default 0.5)
* `smooth_strength`: steepness of the sigmoid (default one)

### Examples

Unsmoothed (zoom at the end):
![image](https://user-images.githubusercontent.com/17097257/174778836-182d1f15-b640-4d10-9a79-4a46d344393c.png)

Smoothed (zoom at the end):
![image](https://user-images.githubusercontent.com/17097257/174778942-96243bc8-2f7d-427e-8b22-5ed4d2c70047.png)


@yger can you test this out?