### PR TITLE
Remove decimate for instability

### DIFF
--- a/MEArec/generators/recgensteps.py
+++ b/MEArec/generators/recgensteps.py
@@ -6,8 +6,8 @@ They can be call in loop mode or with joblib.
 
 Important:
 
-When tmp_mode=='memmap' : theses functions must assign and add directly the buffer.
-When tmp_mode is Noe : theses functions return the buffer and the assignament is done externally.
+When tmp_mode=='memmap' : these functions must assign and add directly the buffer.
+When tmp_mode is None : these functions return the buffer and the assignament is done externally.
 
 
 

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -320,7 +320,7 @@ class RecordingGenerator:
         adc_bit_depth = params['recordings']['adc_bit_depth']
         params['recordings']['lsb'] = rec_params.get('lsb', None)
         lsb = params['recordings']['lsb']
-        if lsb is None:
+        if lsb is None and np.dtype(dtype).kind == "i":
             lsb = 1
         params['recordings']['gain'] = rec_params.get('gain', None)
         gain = params['recordings']['gain']
@@ -1381,8 +1381,6 @@ def run_several_chunks(func, chunk_indexes, fs, lsb, args, n_jobs, tmp_mode, ass
     or in paralell if n_jobs>1
     
     The function can return
-    
-    
     """
 
     # create task list

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -316,6 +316,9 @@ class RecordingGenerator:
         else:
             params['recordings']['dtype'] = rec_params['dtype']
         dtype = params['recordings']['dtype']
+        
+        assert np.dtype(dtype).kind in ("i", "f"), "Only integers and float dtypes are supported"
+        
         params['recordings']['adc_bit_depth'] = rec_params.get('adc_bit_depth', None)
         adc_bit_depth = params['recordings']['adc_bit_depth']
         params['recordings']['lsb'] = rec_params.get('lsb', None)

--- a/MEArec/generators/recordinggenerator.py
+++ b/MEArec/generators/recordinggenerator.py
@@ -1,5 +1,6 @@
 # don't enter here without a good guide! (only one person in the world)
 
+from distutils.log import DEBUG
 import numpy as np
 import time
 from copy import deepcopy
@@ -34,9 +35,9 @@ else:
     use_loader = False
     
     
-debug = True
+DEBUG = False
 
-if debug:
+if DEBUG:
     import matplotlib.pyplot as plt
     plt.ion()
     plt.show()

--- a/MEArec/tools.py
+++ b/MEArec/tools.py
@@ -3457,7 +3457,7 @@ def _jitter_parallel(i, template, upsample, fs, n_jitters, jitter, drifting, ver
                 t_jitt = np.pad(temp_up, [(0, 0), (0, np.abs(shift))], 'constant')[:, -nsamples_up:]
             else:
                 t_jitt = temp_up
-            temp_down = ss.decimate(t_jitt, upsample, axis=1)
+            temp_down = t_jitt[:, ::upsample]
             templates_jitter[n] = temp_down
     else:
         if verbose:

--- a/MEArec/version.py
+++ b/MEArec/version.py
@@ -1,1 +1,1 @@
-version = '1.8.0.dev0'
+version = '1.8.0'


### PR DESCRIPTION
Fixes https://github.com/alejoe91/MEArec/issues/99

Turns out `decimate` behaves weirdly when high upsampling factors are used (probably due to the ant-aliasing filter). Since we are first upsampling and then downsampling, we don't need the anti-aliasing and we can just select every other `upsample` sample