### PR TITLE
Add check_eap_shape parameter for template-generation

### DIFF
--- a/MEArec/default_params/templates_params.yaml
+++ b/MEArec/default_params/templates_params.yaml
@@ -22,6 +22,7 @@ zlim: null # limits ( low high ) for neuron locations in the z-axis
 x_distr: 'uniform' # distribution of x locsations ('uniform' | 'beta')
 beta_distr_params: [1.5, 5] # parameters for beta distribution of x locations (depth)
 min_amp: 30 # minimum amplitude for detection
+check_eap_shape: True # if True, EAPs with negative peaks smaller than positive peaks are discarded
 n: 50 # number of EAPs per cell model
 seed: null # random seed for positions and rotations
 

--- a/MEArec/generators/templategenerator.py
+++ b/MEArec/generators/templategenerator.py
@@ -186,6 +186,8 @@ class TemplateGenerator:
             self.params['det_thresh'] = 30
         if 'n' not in self.params.keys():
             self.params['n'] = 50
+        if 'check_eap_shape' not in self.params.keys():
+            self.params['check_eap_shape'] = True
         if 'min_amp' not in self.params.keys():
             self.params['min_amp'] = 30
         if 'seed' not in self.params.keys():

--- a/MEArec/simulate_cells.py
+++ b/MEArec/simulate_cells.py
@@ -582,6 +582,7 @@ def calc_extracellular(i, cell_model_folder, load_sim_folder, save_sim_folder=No
     x_distr = kwargs['x_distr']
     beta_distr_params = kwargs['beta_distr_params']
     min_amp = kwargs['min_amp']
+    check_shape = kwargs['check_eap_shape']
     MEAname = kwargs['probe']
     drifting = kwargs['drifting']
 
@@ -713,7 +714,7 @@ def calc_extracellular(i, cell_model_folder, load_sim_folder, save_sim_folder=No
                 espikes = espikes * 2
 
             if not drifting:
-                if check_espike(espikes, min_amp):
+                if check_espike(espikes, min_amp, check_shape):
                     skip = skip_duplicate(
                         pos, saved_positions, drifting, verbose)
                     if skip:
@@ -728,7 +729,7 @@ def calc_extracellular(i, cell_model_folder, load_sim_folder, save_sim_folder=No
                             f'Cell: {cell_name} Progress: [{len(saved_eaps)}/{target_num_spikes}]')
                     saved += 1
             else:
-                if check_espike(espikes, min_amp):
+                if check_espike(espikes, min_amp, check_shape):
                     if verbose >= 2:
                         print('template amplitude:', np.round(np.abs(np.min(espikes)), 1))
 
@@ -779,7 +780,7 @@ def calc_extracellular(i, cell_model_folder, load_sim_folder, save_sim_folder=No
                                 if elinfo['type'] == 'mea':
                                     espikes = espikes * 2
 
-                                if check_espike(espikes, min_amp):
+                                if check_espike(espikes, min_amp, check_shape):
                                     if verbose == 2:
                                         print('Found final drifting position')
                                     drift_ok = True
@@ -947,7 +948,7 @@ def calc_extracellular(i, cell_model_folder, load_sim_folder, save_sim_folder=No
         return saved_eaps, saved_positions, saved_rotations
 
 
-def check_espike(espikes, min_amp):
+def check_espike(espikes, min_amp, check_shape=True):
     """
     Check extracellular spike amplitude and shape (neg peak > pos peak)
 
@@ -957,13 +958,17 @@ def check_espike(espikes, min_amp):
         EAP (n_elec, n_samples)
     min_amp: float
         Minimum amplitude
+    check_shape: bool
+        If True, it checks that the minimum peak is larger than the maximum peak
 
     Returns
     -------
     valid: bool
         If True EAP is valid
     """
-    if np.abs(np.min(espikes)) < min_amp or np.abs(np.min(espikes)) < np.abs(np.max(espikes)):
+    if np.abs(np.min(espikes)) < min_amp:
+        return False
+    elif check_shape and np.abs(np.min(espikes)) < np.abs(np.max(espikes)):
         return False
     else:
         return True

--- a/MEArec/tests/test_generators.py
+++ b/MEArec/tests/test_generators.py
@@ -959,7 +959,8 @@ class TestGenerators(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    TestGenerators().setUpClass()
+    test = TestGenerators()
+    test.setUpClass()
     # TestGenerators().test_gen_recordings_drift()
-    # TestGenerators().test_default_params()
-    TestGenerators().test_recordings_backend()
+    test.test_default_params()
+    # test.test_simulate_cell()

--- a/MEArec/version.py
+++ b/MEArec/version.py
@@ -1,1 +1,1 @@
-version = '1.8.0'
+version = '1.8.0.dev0'


### PR DESCRIPTION
@yger can you test this?

Note that since a new parameter is added to the default params file, you need to delete the `~/.config/mearec` folder.

Then you can set the `template_params["check_eap_shape"] = False`