### PR TITLE
Fix filter: use chunk replacement instead of addition

### DIFF
--- a/MEArec/generators/recgensteps.py
+++ b/MEArec/generators/recgensteps.py
@@ -49,6 +49,7 @@ class FuncThenAddChunk:
 
         return return_dict
 
+
 class FuncThenReplaceChunk:
     """
     Helper function to compute by and replace an existing array by chunk.
@@ -354,5 +355,6 @@ def chunk_apply_filter_(ch, i_start, i_stop, fs, lsb,
     return_dict['filtered_chunk'] = filtered_chunk.astype(dtype)
 
     return return_dict
+
 
 chunk_apply_filter = FuncThenReplaceChunk(chunk_apply_filter_)


### PR DESCRIPTION
Fixes #132

Made a new `FuncThenReplaceChunk` used for the filter step that instead of computing a buffer and then adding to the existing traces (done by convolution and additive noise), it replaces them